### PR TITLE
Agendando tarefas com spring

### DIFF
--- a/adopet-store/src/main/java/br/com/alura/adopetstore/AdopetStoreApplication.java
+++ b/adopet-store/src/main/java/br/com/alura/adopetstore/AdopetStoreApplication.java
@@ -3,9 +3,11 @@ package br.com.alura.adopetstore;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableAsync
+@EnableScheduling
 public class AdopetStoreApplication {
 
 	public static void main(String[] args) {

--- a/adopet-store/src/main/java/br/com/alura/adopetstore/controller/RelatorioController.java
+++ b/adopet-store/src/main/java/br/com/alura/adopetstore/controller/RelatorioController.java
@@ -1,3 +1,4 @@
+/*
 package br.com.alura.adopetstore.controller;
 
 import br.com.alura.adopetstore.dto.RelatorioEstoque;
@@ -26,4 +27,4 @@ public class RelatorioController {
         var relatorio = service.faturamentoObtido();
         return ResponseEntity.ok(relatorio);
     }
-}
+}*/

--- a/adopet-store/src/main/java/br/com/alura/adopetstore/email/EmailRelatorioGerado.java
+++ b/adopet-store/src/main/java/br/com/alura/adopetstore/email/EmailRelatorioGerado.java
@@ -1,0 +1,28 @@
+package br.com.alura.adopetstore.email;
+
+import br.com.alura.adopetstore.dto.RelatorioEstoque;
+import br.com.alura.adopetstore.dto.RelatorioFaturamento;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class EmailRelatorioGerado {
+    @Autowired
+    private EnviadorEmail enviador;
+
+    public void enviar(RelatorioEstoque estoque, RelatorioFaturamento faturamento){
+        enviador.enviarEmail(
+                "Relatórios gerados",
+                "admin@email.com",
+                """
+                            Olá! 
+                            
+                            Seus relatórios foram gerados:
+                            
+                            %s
+                            
+                            %s
+                        """.formatted(estoque, faturamento)
+        );
+    }
+}

--- a/adopet-store/src/main/java/br/com/alura/adopetstore/service/AgendamentoService.java
+++ b/adopet-store/src/main/java/br/com/alura/adopetstore/service/AgendamentoService.java
@@ -1,0 +1,29 @@
+package br.com.alura.adopetstore.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AgendamentoService {
+
+    @Autowired
+    private RelatorioService relatorioService;
+
+    /*
+    * O cron é semelhante a uma expressão regular, na qual passamos seis campos relacionados ao tempo, nessa ordem:
+    * segundo, minuto, hora, dia, mês e ano.
+    * Se configurássemos, por exemplo, duas horas e qualquer segundo ("* 0 2 * *"), ele enviaria um e-mail a cada
+    * segundo dentro dessa hora do dia.
+    * Por isso, é importante que nos atentemos bastante ao que escrevemos nessa expressão.
+     */
+    //
+    @Scheduled(cron = "0 54 17 * * *")
+    public void envioEmailAgendamento(){
+        var estoqueZerado = relatorioService.infoEstoque();
+        var faturamentoObtido = relatorioService.faturamentoObtido();
+
+        System.out.println("Estoque Zerado: " + estoqueZerado);
+        System.out.println("Faturamento Obtido: " + faturamentoObtido);
+    }
+}

--- a/adopet-store/src/main/java/br/com/alura/adopetstore/service/AgendamentoService.java
+++ b/adopet-store/src/main/java/br/com/alura/adopetstore/service/AgendamentoService.java
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 @Service
@@ -28,6 +29,9 @@ public class AgendamentoService {
     public void envioEmailAgendamento(){
         var estoqueZerado = relatorioService.infoEstoque();
         var faturamentoObtido = relatorioService.faturamentoObtido();
+
+        //Sincronizando as threads com a thread corrente main
+        CompletableFuture.allOf(estoqueZerado, faturamentoObtido).join();
 
         try {
             enviador.enviar(estoqueZerado.get(), faturamentoObtido.get());

--- a/adopet-store/src/main/java/br/com/alura/adopetstore/service/AgendamentoService.java
+++ b/adopet-store/src/main/java/br/com/alura/adopetstore/service/AgendamentoService.java
@@ -1,14 +1,20 @@
 package br.com.alura.adopetstore.service;
 
+import br.com.alura.adopetstore.email.EmailRelatorioGerado;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+
+import java.util.concurrent.ExecutionException;
 
 @Service
 public class AgendamentoService {
 
     @Autowired
     private RelatorioService relatorioService;
+
+    @Autowired
+    private EmailRelatorioGerado enviador;
 
     /*
     * O cron é semelhante a uma expressão regular, na qual passamos seis campos relacionados ao tempo, nessa ordem:
@@ -18,12 +24,19 @@ public class AgendamentoService {
     * Por isso, é importante que nos atentemos bastante ao que escrevemos nessa expressão.
      */
     //
-    @Scheduled(cron = "0 54 17 * * *")
+    @Scheduled(cron = "0 27 20 * * *")
     public void envioEmailAgendamento(){
         var estoqueZerado = relatorioService.infoEstoque();
         var faturamentoObtido = relatorioService.faturamentoObtido();
 
-        System.out.println("Estoque Zerado: " + estoqueZerado);
-        System.out.println("Faturamento Obtido: " + faturamentoObtido);
+        try {
+            enviador.enviar(estoqueZerado.get(), faturamentoObtido.get());
+        } catch (InterruptedException | ExecutionException e) {
+            throw new RuntimeException(e);
+        }
+//        System.out.println("Estoque Zerado: " + estoqueZerado);
+//        System.out.println("Faturamento Obtido: " + faturamentoObtido);
+        System.out.println("Thread Agendamento: "+ Thread.currentThread().getName());
+
     }
 }

--- a/adopet-store/src/main/java/br/com/alura/adopetstore/service/RelatorioService.java
+++ b/adopet-store/src/main/java/br/com/alura/adopetstore/service/RelatorioService.java
@@ -31,7 +31,7 @@ public class RelatorioService {
     }
 
     public RelatorioFaturamento faturamentoObtido() {
-        var dataOntem = LocalDate.now().minusDays(1);
+        var dataOntem = LocalDate.now();
         var faturamentoTotal = pedidoRepository.faturamentoTotalDoDia(dataOntem);
 
         var estatisticas = pedidoRepository.faturamentoTotalDoDiaPorCategoria(dataOntem);

--- a/adopet-store/src/main/java/br/com/alura/adopetstore/service/RelatorioService.java
+++ b/adopet-store/src/main/java/br/com/alura/adopetstore/service/RelatorioService.java
@@ -7,9 +7,11 @@ import br.com.alura.adopetstore.repository.EstoqueRepository;
 import br.com.alura.adopetstore.repository.PedidoRepository;
 import br.com.alura.adopetstore.repository.ProdutoRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 @Service
@@ -23,19 +25,21 @@ public class RelatorioService {
     @Autowired
     private PedidoRepository pedidoRepository;
 
-    public RelatorioEstoque infoEstoque(){
+    @Async
+    public CompletableFuture<RelatorioEstoque> infoEstoque(){
         var produtosSemEstoque = estoqueRepository.produtosComEstoqueZerado()
                 .stream().map(ProdutoDTO::new)
                 .collect(Collectors.toList());
-        return new RelatorioEstoque(produtosSemEstoque);
+        return CompletableFuture.completedFuture(new RelatorioEstoque(produtosSemEstoque));
     }
 
-    public RelatorioFaturamento faturamentoObtido() {
+    @Async
+    public CompletableFuture<RelatorioFaturamento> faturamentoObtido() {
         var dataOntem = LocalDate.now();
         var faturamentoTotal = pedidoRepository.faturamentoTotalDoDia(dataOntem);
 
         var estatisticas = pedidoRepository.faturamentoTotalDoDiaPorCategoria(dataOntem);
 
-        return new RelatorioFaturamento(faturamentoTotal, estatisticas);
+        return CompletableFuture.completedFuture(new RelatorioFaturamento(faturamentoTotal, estatisticas));
     }
 }


### PR DESCRIPTION
- Agendar tarefas com Spring Boot. Vimos que precisamos habilitar o agendamento na classe principal, além de usar a anotação @scheduled. Existem várias formas de agendar uma tarefa. Conhecemos o cron, mas pudemos ver os outros também.
- O agendamento de tarefas está relacionado com threads. Temos tarefas independentes na aplicação rodando paralelamente. Por isso, o agendamento cria uma thread.
- Recuperar o retorno de uma thread com CompletableFuture. Quando queremos um retorno da thread depois de executada, precisamos de um Future. Usamos uma definição mais específica do Future, que era a CompletableFuture.
- Utilizar vários métodos de CompletableFuture. Vimos na prática a classe e conhecemos sua documentação, além de explorar boas práticas com o uso do join().